### PR TITLE
feature/health fixes

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -29,6 +29,12 @@ vim.g.loaded_netrwPlugin = 1
 -- optionally enable 24-bit colour
 vim.opt.termguicolors = true
 
+-- Disable language providers not in use
+vim.g.loaded_node_provider = 0
+vim.g.loaded_perl_provider = 0
+vim.g.loaded_python3_provider = 0
+vim.g.loaded_ruby_provider = 0
+
 -- #############################################################
 -- Keymaps
 
@@ -64,6 +70,7 @@ vim.api.nvim_exec([[
 -- Download plugins
 require ('config.plugins')
 -- Load plugins and configurations
+require('config.treesitter')
 require('config.tokyonight')
 require('config.markdown-renderer')
 require('config.lazygit-setup')
@@ -77,3 +84,4 @@ require('config.notify')
 require('config.noice')
 require('config.nvim-web-devicons')
 require('config.smear-cursor')
+require('config.treesitter')

--- a/nvim/lua/config/markdown-renderer.lua
+++ b/nvim/lua/config/markdown-renderer.lua
@@ -102,7 +102,7 @@ require('render-markdown').setup({
     },
     latex = {
         -- Turn on / off latex rendering.
-        enabled = true,
+        enabled = false,
         -- Additional modes to render latex.
         render_modes = false,
         -- Executable used to convert latex formula to rendered unicode.
@@ -700,7 +700,7 @@ require('render-markdown').setup({
     },
     html = {
         -- Turn on / off all HTML rendering.
-        enabled = true,
+        enabled = false,
         -- Additional modes to render HTML.
         render_modes = false,
         comment = {
@@ -768,7 +768,7 @@ require('render-markdown').setup({
     },
     yaml = {
         -- Turn on / off all yaml rendering.
-        enabled = true,
+        enabled = false,
         -- Additional modes to render yaml.
         render_modes = false,
     },

--- a/nvim/lua/config/noice.lua
+++ b/nvim/lua/config/noice.lua
@@ -1,4 +1,14 @@
 require("noice").setup({
+	presets = {
+		lsp_doc_border = true,
+	},
+	lsp = {
+		override = {
+			["vim.lsp.util.convert_input_to_markdown_lines"] = true,
+			["vim.lsp.util.stylize_markdown"] = true,
+			["cmp.entry.get_documentation"] = true,
+		},
+	},
 	views = {
 		notify = {
     		enabled = true,

--- a/nvim/lua/config/plugins.lua
+++ b/nvim/lua/config/plugins.lua
@@ -46,5 +46,8 @@ vim.pack.add({
 	--UI components (floating windows, input, select)
 	'https://github.com/MunifTanjim/nui.nvim.git',
 	---Smear cursor
-	"https://github.com/sphamba/smear-cursor.nvim"
+	"https://github.com/sphamba/smear-cursor.nvim",
+
+	----Treesitter
+	'https://github.com/nvim-treesitter/nvim-treesitter.git',
 })

--- a/nvim/lua/config/terraform.lua
+++ b/nvim/lua/config/terraform.lua
@@ -1,4 +1,28 @@
--- vim-terraform plugin configuration
--- Auto-format on save (optional)
-vim.g.terraform_fmt_on_save = 1
-vim.g.terraform_align = 1
+local api = vim.api
+local fn = vim.fn
+local notify = vim.notify
+
+vim.g.terraform_fmt_on_save = 0
+
+api.nvim_create_autocmd("BufWritePre", {
+  group = api.nvim_create_augroup("TerraformFmt", { clear = true }),
+  pattern = { "*.tf", "*.tfvars" },
+  callback = function()
+    local bufnr = api.nvim_get_current_buf()
+    local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    local input = table.concat(lines, "\n")
+
+    local result = fn.system("terraform fmt -check -no-color -", input)
+
+    if vim.v.shell_error ~= 0 then
+      notify(result, vim.log.levels.ERROR, { title = "Terraform Format" })
+      return
+    end
+
+    local formatted = fn.system("terraform fmt -no-color -", input)
+
+    if vim.v.shell_error == 0 and formatted ~= input then
+      api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(formatted, "\n"))
+    end
+  end,
+})

--- a/nvim/lua/config/treesitter.lua
+++ b/nvim/lua/config/treesitter.lua
@@ -1,0 +1,5 @@
+require('nvim-treesitter').setup({
+  ensure_installed = { 'regex', 'bash', 'html', 'yaml' },
+  auto_install = true,
+  highlight = { enable = true },
+})

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -146,3 +146,4 @@ git-ssh-agent() {
   source "$HOME/configFiles/scripts/git-ssh-agent.sh"
 }
 export PATH=$HOME/.local/bin:$PATH
+export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"


### PR DESCRIPTION
Fixes:

- nvim: add treesitter parser configuration for missing parsers
- nvim: disable unused language providers to clean checkhealth
- nvim: add nvim-treesitter plugin for parser management
- nvim: configure noice.nvim lsp overrides to suppress warnings
- nvim: disable unsupported render-markdown features to clean checkhealth
- nvim: replace terraform fmt handler with vim.notify for visible errors
- zsh: add krew binary path to PATH
